### PR TITLE
minor modifications in text

### DIFF
--- a/notebooks/spectrogram_generator.ipynb
+++ b/notebooks/spectrogram_generator.ipynb
@@ -9,8 +9,8 @@
     }
    },
    "source": [
-    "# PREAMBLE\n",
-    "Here are imported a few librairies to run the codes\n"
+    "# PREAMBULE\n",
+    "Here are imported a few librairies to run the codes"
    ]
   },
   {
@@ -54,6 +54,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`list_dataset` take as an argument the path to the datasets : `path_osmose` and the campaign path which is a optional argument in the case where several datasets are grouped into a single folder, leave `campaign = \"\"` if the dataset is directly located in `path_osmose`"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -65,7 +72,8 @@
    "outputs": [],
    "source": [
     "# FILL IN RED PARTS !\n",
-    "list_dataset(path_osmose_dataset, \"\")"
+    "\n",
+    "list_dataset(path_osmose=path_osmose_dataset, campaign=\"\")"
    ]
   },
   {
@@ -351,7 +359,7 @@
     "\n",
     "- `dataset.batch_number` indicates the number of concurrent jobs. A higher number can speed things up until a certain point. It still does not work very well.\n",
     "\n",
-    "- **If you create your spectrograms for an APLOSE campaign, set** - `write_datasets_csv_for_APLOSE=True` **below !**\n",
+    "- **If you create your spectrograms for an APLOSE campaign, set** `write_datasets_csv_for_APLOSE=True` **below !**\n",
     "\n",
     "- The variable below `save_matrix` should be set to True if you want to generate the numpy matrices along your png spectrograms"
    ]

--- a/notebooks/spectrogram_generator.ipynb
+++ b/notebooks/spectrogram_generator.ipynb
@@ -9,9 +9,8 @@
     }
    },
    "source": [
-    "# PREAMBULE\n",
-    "Here are imported a few librairies to run the codes\n",
-    "You simply have to adapt `path_osmose_home` which points to OSmOSE working directory\n"
+    "# PREAMBLE\n",
+    "Here are imported a few librairies to run the codes\n"
    ]
   },
   {

--- a/notebooks/spectrogram_generator.ipynb
+++ b/notebooks/spectrogram_generator.ipynb
@@ -394,7 +394,7 @@
     "# JUST RUN THIS CELL : NOTHING TO FILL IN!\n",
     "dataset.initialize(\n",
     "    env_name=sys.executable.replace(\"/bin/python\", \"\"),\n",
-    "    force_init=True,\n",
+    "    force_init=False,\n",
     "    last_file_behavior=\"discard\",\n",
     "    reshape_method=\"none\",\n",
     ")"

--- a/notebooks/spectrogram_generator.ipynb
+++ b/notebooks/spectrogram_generator.ipynb
@@ -369,7 +369,7 @@
    "source": [
     "# FILL IN GREEN PARTS !\n",
     "dataset.batch_number = 2\n",
-    "write_datasets_csv_for_APLOSE = True\n",
+    "write_datasets_csv_for_APLOSE = False\n",
     "save_matrix = False"
    ]
   },


### PR DESCRIPTION
I would remove the sentence "You simply have to adapt `path_osmose_home` which points to OSmOSE working directory\n" , because lambda user does not have to worry about path_osmose_home 

However i would rather put a sentence about the copy and past of the folder datarmor-toolkit within the datahome