### PR TITLE
set valid default log directory for job files

### DIFF
--- a/src/qsub_spectrogram_generator_pkg.py
+++ b/src/qsub_spectrogram_generator_pkg.py
@@ -47,13 +47,15 @@ if __name__ == "__main__":
         help="Whether to save the spectrogram matrices or not. Note that activating this parameter might increase greatly the volume of the project.",
     )
     parser.add_argument("--save-for-LTAS", action="store_true")
+    parser.add_argument("--spectrogram-metadata-path", type = str, default = '')
 
     args = parser.parse_args()
 
     print("Parameters :", args)
 
     os.system("ln -sf /appli/sox/sox-14.4.2_gcc-7.2.0/bin/sox sox")
-    dataset = Spectrogram(args.dataset_path, dataset_sr=args.dataset_sr)
+
+    dataset = Spectrogram.from_csv(dataset_path = args.dataset_path, metadata_csv_path = args.spectrogram_metadata_path)
 
     if not dataset.path.joinpath("processed", "spectrogram", "adjust_metadata.csv"):
         raise FileNotFoundError(

--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -214,7 +214,7 @@ def generate_spectro(
 
     batch_size = nber_files_to_process // dataset.batch_number
 
-    jobfile = None
+    jobfiles = []
 
     dataset.prepare_paths()
     spectrogram_metadata_path = dataset.save_spectro_metadata(False)
@@ -247,6 +247,8 @@ def generate_spectro(
             logdir=log_dir,
         )
 
+        jobfiles.append(jobfile)
+
     if hasattr(dataset, "pending_jobs"):
         pending_jobs = [
             jobid
@@ -257,10 +259,10 @@ def generate_spectro(
     else:
         pending_jobs = []
 
-    job_id_list = dataset.jb.submit_job(
+    job_id_list = [dataset.jb.submit_job(
         jobfile = jobfile,
         dependency=pending_jobs
-    )  # submit all built job files
+    ) for jobfile in jobfiles]  # submit all built job files
     nb_jobs = len(dataset.jb.finished_jobs) + len(job_id_list)
 
     if pending_jobs:

--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from OSmOSE import Spectrogram
-from OSmOSE.config import SUPPORTED_AUDIO_FORMAT
+from OSmOSE.config import SUPPORTED_AUDIO_FORMAT, OSMOSE_PATH
 from OSmOSE.cluster import reshape
 import random
 import os
@@ -144,7 +144,7 @@ def adjust_spectro(
 def generate_spectro(
     dataset: Spectrogram,
     path_osmose_dataset: Union[str, Path],
-    write_datasets_csv_for_APLOSE: bool = False,
+    write_datasets_csv_for_aplose: bool = False,
     overwrite: bool = False,
     save_matrix: bool = False,
     save_welch: bool = False,
@@ -156,18 +156,14 @@ def generate_spectro(
         dataset, datetime_begin, datetime_end
     )
 
-    prepared_jobs = [job["path"].parent for job in (dataset.jb.prepared_jobs)]
-    ongoing_jobs = [job["path"].parent for job in (dataset.jb.ongoing_jobs)]
-    cancelled_jobs = [job["path"].parent for job in (dataset.jb.cancelled_jobs)]
-    finished_jobs = [job["path"].parent for job in (dataset.jb.finished_jobs)]
-    all_jobs = prepared_jobs + ongoing_jobs + cancelled_jobs + finished_jobs
-    log_dir = list(set(all_jobs))[0]
+    first_job = next(iter(dataset.jb.all_jobs), None)
+    log_dir = (dataset.path / OSMOSE_PATH.log) if first_job is None else first_job["path"].parent
 
     assert isinstance(
         dataset, Spectrogram
     ), "Not a Spectrogram object passed, adjustment aborted"
     assert isinstance(
-        write_datasets_csv_for_APLOSE, bool
+        write_datasets_csv_for_aplose, bool
     ), "'write_datasets_csv_for_APLOSE' must be a boolean value"
     assert isinstance(overwrite, bool), "'overwrite' must be a boolean value"
     assert isinstance(save_matrix, bool), "'save_matrix' must be a boolean value"
@@ -183,7 +179,7 @@ def generate_spectro(
         datetime_end, pd.Timestamp
     ), f"'datetime_end' must be either 'None' or a datetime, {datetime_end} not a valid value"
 
-    if write_datasets_csv_for_APLOSE is True:
+    if write_datasets_csv_for_aplose is True:
 
         file_type = list(
             set([f.suffix for f in get_all_audio_files(dataset.original_folder)])


### PR DESCRIPTION
fix a bug where an exception was raised if the user called `generate_spectro()` without having to `initialize()` the dataset (e.g. when only the output spectrogram parameters were changed), by giving a default value to the log folder (in which the job files are temporary stored before being killed).

Still needs update on the [OSEkit](https://github.com/Project-OSmOSE/OSEkit/pull/205) side to be 100% functional.