### PR TITLE
Fix list of file sent to the spectrogram generator

### DIFF
--- a/src/qsub_spectrogram_generator_pkg.py
+++ b/src/qsub_spectrogram_generator_pkg.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     required.add_argument(
         "--dataset-path", "-p", required=True, help="The path to the dataset folder"
     )
-    parser.add_argument("--files", "-f", type=list)
+    parser.add_argument("--files", "-f", nargs="*")
     parser.add_argument(
         "--overwrite",
         action="store_true",
@@ -65,8 +65,7 @@ if __name__ == "__main__":
     files = get_all_audio_files(dataset.audio_path)
 
     if args.files:
-        selected_files = args.files.split(" ")
-
+        selected_files = args.files
         if not all(dataset.audio_path.joinpath(f) in files for f in selected_files):
             raise FileNotFoundError(
                 f"At least one file in {selected_files} has not been found in {files}"

--- a/src/qsub_spectrogram_generator_pkg.py
+++ b/src/qsub_spectrogram_generator_pkg.py
@@ -8,6 +8,7 @@ import itertools
 import pandas as pd
 from pathlib import Path
 from OSmOSE.utils.audio_utils import get_all_audio_files
+from babel.util import missing
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -21,24 +22,11 @@ if __name__ == "__main__":
         "--dataset-path", "-p", required=True, help="The path to the dataset folder"
     )
     parser.add_argument("--files", "-f", nargs="*")
+    parser.add_argument("--first-file-index", "-i", required = True, help = "The index of the first file considered by this batch")
     parser.add_argument(
         "--overwrite",
         action="store_true",
         help="Deletes all existing spectrograms and their zoom levels matching the audio file before processing. If some spectrograms do not match any processed audio files, they will not be deleted.",
-    )
-    parser.add_argument(
-        "--batch-ind-min",
-        "-min",
-        type=int,
-        default=0,
-        help="The first file to consider. Default is 0.",
-    )
-    parser.add_argument(
-        "--batch-ind-max",
-        "-max",
-        type=int,
-        default=-1,
-        help="The last file to consider. -1 means consider all files from batch-ind-min. Default is -1",
     )
     parser.add_argument(
         "--save-matrix",
@@ -62,28 +50,15 @@ if __name__ == "__main__":
             f"The file adjust_metadata.csv has not been found in the processed/spectrogram folder. Consider using the initialize() or update_parameters() methods."
         )
 
-    files = get_all_audio_files(dataset.audio_path)
+    files = [Path(file) for file in args.files]
 
-    if args.files:
-        selected_files = args.files
-        if not all(dataset.audio_path.joinpath(f) in files for f in selected_files):
-            raise FileNotFoundError(
-                f"At least one file in {selected_files} has not been found in {files}"
-            )
-        else:
-            files = selected_files
-
-    print(f"Found {len(files)} files in {dataset.audio_path}.")
-
-    files_to_process = files[
-        args.batch_ind_min : (
-            args.batch_ind_max + 1 if args.batch_ind_max != -1 else len(files)
+    if missing_files := [file for file in files if not file.exists()]:
+        missing_file_list = "\n".join(str(file) for file in missing_files)
+        raise FileNotFoundError(
+            f"Missing files: {missing_file_list}"
         )
-    ]
 
-    print(f"files to process: {files_to_process}\n")
-
-    for i, audio_file in enumerate(files_to_process):
+    for audio_file in files:
         print(audio_file)
 
         dataset.process_file(
@@ -95,7 +70,7 @@ if __name__ == "__main__":
             overwrite=args.overwrite,
         )
 
-    if args.save_for_LTAS and args.save_matrix:
+    if False and args.save_for_LTAS and args.save_matrix:
 
         # get metadata from spectrogram folder
         metadata_path = next(
@@ -114,7 +89,7 @@ if __name__ == "__main__":
         Sxx = np.empty((1, int(metadata_spectrogram["nfft"][0] / 2) + 1))
         Time = []
 
-        print(f"number of welch: {len(files_to_process)}")
+        print(f"number of welch: {len(files)}")
 
         for file_npz in files_to_process:
             file_npz = dataset.path.joinpath(

--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -199,13 +199,14 @@ def generate_spectro(
             path=path_osmose_dataset, file="datasets.csv", info=dataset_info
         )
 
-    files = _files_in_analysis(datetime_begin=datetime_begin, datetime_end=datetime_end, audio_folder=dataset.audio_path)
-    batch_sizes = _compute_batch_sizes(nb_files = len(files), nb_batches = dataset.batch_number)
-    batch_indexes = [sum(batch_sizes[:i]) for i in range(len(batch_sizes))]
-
     jobfiles = []
 
     dataset.prepare_paths()
+
+    files = _files_in_analysis(datetime_begin=datetime_begin, datetime_end=datetime_end, audio_folder=dataset.audio_path)
+    batch_sizes = _compute_batch_sizes(nb_files = len(files), nb_batches = dataset.batch_number)
+    batch_indexes = [sum(batch_sizes[:i]) for i in range(len(batch_sizes))]
+    
     spectrogram_metadata_path = dataset.save_spectro_metadata(False)
 
     for batch in range(len(batch_indexes)):

--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -369,8 +369,10 @@ def display_progress(dataset: Spectrogram, datetime_begin: str, datetime_end: st
 
 def _files_in_analysis(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp, audio_folder: Path) -> list[str]:
     timestamps = pd.read_csv(audio_folder / "timestamp.csv")
-    timestamps["timestamp"] = timestamps["timestamp"].apply(lambda t: pd.Timestamp(t))
-    return [str(audio_folder/filename) for filename in timestamps.loc[(datetime_begin <= timestamps["timestamp"]) & (timestamps["timestamp"] <= datetime_end), "filename"]]
+    file_duration = float(pd.read_csv(audio_folder / "metadata.csv")["audio_file_dataset_duration"][0])
+    timestamps["begin"] = timestamps["timestamp"].apply(lambda t: pd.Timestamp(t))
+    timestamps["end"] = timestamps["begin"] + pd.Timedelta(seconds=file_duration)
+    return [str(audio_folder/filename) for filename in timestamps.loc[(datetime_begin <= timestamps["end"]) & (datetime_end >= timestamps["begin"]), "filename"]]
 
 def _compute_batch_sizes(nb_files: int, nb_batches: int):
     base_numbers_of_files = [nb_files // nb_batches] * nb_batches

--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -372,7 +372,7 @@ def _files_in_analysis(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp,
     file_duration = float(pd.read_csv(audio_folder / "metadata.csv")["audio_file_dataset_duration"][0])
     timestamps["begin"] = timestamps["timestamp"].apply(lambda t: pd.Timestamp(t))
     timestamps["end"] = timestamps["begin"] + pd.Timedelta(seconds=file_duration)
-    return [str(audio_folder/filename) for filename in timestamps.loc[(datetime_begin <= timestamps["end"]) & (datetime_end >= timestamps["begin"]), "filename"]]
+    return [str(audio_folder/filename) for filename in timestamps.loc[(datetime_begin < timestamps["end"]) & (datetime_end > timestamps["begin"]), "filename"]]
 
 def _compute_batch_sizes(nb_files: int, nb_batches: int):
     base_numbers_of_files = [nb_files // nb_batches] * nb_batches


### PR DESCRIPTION
This PR is related to the issue #58.

Basically, at the moment the procedure was the following:

- A number of files to process was computed either by dividing the total time range by the duration of the spectrograms (if dataset.concat is True) or by catching the `dataset.list_audio_to_process` attribute:

```py
if dataset.concat:
    new_file = list(
        pd.date_range(
            start=datetime_begin,
            end=datetime_end,
            freq=f"{dataset.spectro_duration}s",
        )
    )
    nber_files_to_process = len(new_file) - 1
else:
    nber_files_to_process = len(dataset.list_audio_to_process)
```

Then, indices were passed to each job file to distribute the files:

```py
for batch in range(dataset.batch_number):
    i_min = batch * batch_size
    i_max = (
        i_min + batch_size
        if batch < dataset.batch_number - 1
        else len(files)
    )  # If it is the last batch, take all files
```

This led to 2 issues:
- The `dataset.list_audio_to_process` attribute is set during the `initialize()` Spectrogram method. Calling `generate_spectro()` on an already-initialized spectrogram which mess the number of genereated spectrograms.
- If the `datetime_begin` and `datetime_end` attributes are changed, the spectrograms will nevertheless be computed from the oldest audio file no matter what.

The changes proposed here are to:

- Compute the list of files of which the spectrograms will be drawn from their timestamps, relative to `datetime_begin` and `datetime_end`
- Use the same logic for both states of `dataset.concat`

This fix is quite temporary, as I am currently working on timestamps-related things on the OSEkit side. I think the whole access to which files are concerned by an analysis should be left to OSEkit more than the datarmor-toolkit, so I might end up moving things there.