### PR TITLE
Hotfix/async spectro generation

### DIFF
--- a/src/qsub_spectrogram_generator_pkg.py
+++ b/src/qsub_spectrogram_generator_pkg.py
@@ -9,6 +9,26 @@ from OSmOSE.config import *
 from OSmOSE.utils.audio_utils import get_all_audio_files
 from babel.util import missing
 
+def _get_batch_files(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp, batch_index: int, total_number_of_batches: int, audio_folder: Path) -> list[Path]:
+    total_files = _files_in_analysis(datetime_begin, datetime_end, audio_folder)
+    batch_sizes = _compute_batch_sizes(len(total_files), total_number_of_batches)
+    batch_first_file_indexes = [sum(batch_sizes[:i]) for i in range(len(batch_sizes))]
+    first_file_index = batch_first_file_indexes[batch_index]
+    last_file_index = first_file_index + batch_sizes[batch_index]
+    return total_files[first_file_index:last_file_index]
+
+def _files_in_analysis(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp, audio_folder: Path) -> list[Path]:
+    timestamps = pd.read_csv(audio_folder / "timestamp.csv")
+    file_duration = float(pd.read_csv(audio_folder / "metadata.csv")["audio_file_dataset_duration"][0])
+    timestamps["begin"] = timestamps["timestamp"].apply(lambda t: pd.Timestamp(t))
+    timestamps["end"] = timestamps["begin"] + pd.Timedelta(seconds=file_duration)
+    return [Path(audio_folder/filename) for filename in timestamps.loc[(datetime_begin < timestamps["end"]) & (datetime_end > timestamps["begin"]), "filename"]]
+
+def _compute_batch_sizes(nb_files: int, nb_batches: int):
+    base_numbers_of_files = [nb_files // nb_batches] * nb_batches
+    remainder_files = nb_files % nb_batches
+    return [nb_files+1 if index < remainder_files else nb_files for index,nb_files in enumerate(base_numbers_of_files)]
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Python script to process a list of file and generate spectrograms."
@@ -20,8 +40,10 @@ if __name__ == "__main__":
     required.add_argument(
         "--dataset-path", "-p", required=True, help="The path to the dataset folder"
     )
-    parser.add_argument("--files", "-f", nargs="*")
-    parser.add_argument("--first-file-index", "-i", required = True, help = "The index of the first file considered by this batch")
+    parser.add_argument("--datetime-begin", "-db", type=str)
+    parser.add_argument("--datetime-end", "-de", type=str)
+    parser.add_argument("--batch-index", "-i", type=int)
+    parser.add_argument("--nb-batches", "-n", type=int)
     parser.add_argument(
         "--overwrite",
         action="store_true",
@@ -51,7 +73,10 @@ if __name__ == "__main__":
             f"The file adjust_metadata.csv has not been found in the processed/spectrogram folder. Consider using the initialize() or update_parameters() methods."
         )
 
-    files = [Path(file) for file in args.files]
+    datetime_begin = pd.Timestamp(args.datetime_begin)
+    datetime_end = pd.Timestamp(args.datetime_end)
+
+    files = _get_batch_files(datetime_begin=datetime_begin, datetime_end=datetime_end, batch_index = args.batch_index, total_number_of_batches = args.nb_batches, audio_folder = dataset.audio_path)
 
     if missing_files := [file for file in files if not file.exists()]:
         missing_file_list = "\n".join(str(file) for file in missing_files)

--- a/src/qsub_spectrogram_generator_pkg.py
+++ b/src/qsub_spectrogram_generator_pkg.py
@@ -5,9 +5,8 @@ import itertools
 import pandas as pd
 
 from OSmOSE import Spectrogram
-from OSmOSE.config import *
-from OSmOSE.utils.audio_utils import get_all_audio_files
-from babel.util import missing
+from pathlib import Path
+from OSmOSE.config import OSMOSE_PATH
 
 def _get_batch_files(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp, batch_index: int, total_number_of_batches: int, audio_folder: Path) -> list[Path]:
     total_files = _files_in_analysis(datetime_begin, datetime_end, audio_folder)
@@ -117,7 +116,7 @@ if __name__ == "__main__":
 
         print(f"number of welch: {len(files)}")
 
-        for file_npz in files_to_process:
+        for file_npz in files:
             file_npz = dataset.path.joinpath(
                 OSMOSE_PATH.welch,
                 dataset.audio_path.name,

--- a/src/qsub_spectrogram_generator_pkg.py
+++ b/src/qsub_spectrogram_generator_pkg.py
@@ -8,22 +8,84 @@ from OSmOSE import Spectrogram
 from pathlib import Path
 from OSmOSE.config import OSMOSE_PATH
 
-def _get_batch_files(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp, batch_index: int, total_number_of_batches: int, audio_folder: Path) -> list[Path]:
-    total_files = _files_in_analysis(datetime_begin, datetime_end, audio_folder)
-    batch_sizes = _compute_batch_sizes(len(total_files), total_number_of_batches)
+def _get_files_processed_by_current_batch(all_files: list[Path], batch_index: int, total_number_of_batches: int) -> list[Path]:
+    """
+    Compute which files are concerned by this batch.
+
+    Parameters
+    ----------
+    all_files: list[str]
+        List of all the files processed by all batches
+    batch_index:
+        Index of the current batch
+    total_number_of_batches:
+        Total number of batches running the process
+
+
+    Returns
+    -------
+    list[pathlib.Path]:
+        List of the files processed by the current batch
+    """
+
+    batch_sizes = _compute_batch_sizes(len(all_files), total_number_of_batches)
     batch_first_file_indexes = [sum(batch_sizes[:i]) for i in range(len(batch_sizes))]
     first_file_index = batch_first_file_indexes[batch_index]
     last_file_index = first_file_index + batch_sizes[batch_index]
-    return total_files[first_file_index:last_file_index]
+    return all_files[first_file_index:last_file_index]
 
-def _files_in_analysis(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp, audio_folder: Path) -> list[Path]:
+def _get_all_processed_files(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp, audio_folder: Path) -> list[Path]:
+    """
+    Compute which files are concerned by the whole analysis (all batches included).
+
+    Since the timestamp.csv file might not exist at the time where this job file is created,
+    every batch has to compute it (since the execution of this file is delayed until all
+    initialize() jobs are completed).
+    Parameters
+    ----------
+    datetime_begin: pandas.Timestamp
+        Timestamp of the beginning of the process
+    datetime_end: pandas.Timestamp
+        Timestamp of the end of the process
+    audio_folder: pathlib.Path
+        Path to the reshaped audio folder
+
+    Returns
+    -------
+    list[pathlib.Path]:
+        The list of files for which spectrograms should be plotted.
+    """
     timestamps = pd.read_csv(audio_folder / "timestamp.csv")
     file_duration = float(pd.read_csv(audio_folder / "metadata.csv")["audio_file_dataset_duration"][0])
     timestamps["begin"] = timestamps["timestamp"].apply(lambda t: pd.Timestamp(t))
     timestamps["end"] = timestamps["begin"] + pd.Timedelta(seconds=file_duration)
     return [Path(audio_folder/filename) for filename in timestamps.loc[(datetime_begin < timestamps["end"]) & (datetime_end > timestamps["begin"]), "filename"]]
 
-def _compute_batch_sizes(nb_files: int, nb_batches: int):
+def _compute_batch_sizes(nb_files: int, nb_batches: int) -> list[int]:
+    """
+    Compute the number of files processed by each batch in the analysis.
+
+    Parameters
+    ----------
+    nb_files: int
+        Number of files processed by ball batches
+    nb_batches: int
+        Number of batches in the analysis
+
+    Returns
+    -------
+    list(int):
+    A list representing the number of files processed by each batch in the analysis.
+
+    Examples
+    --------
+    >>> _compute_batch_sizes(10,4)
+    [3,3,2,2]
+    """
+    """Compute the number of files processed by each batch in the analysis.
+
+    The number of file is equitably distributed among batches.
+    Example: 10 files distributed among 4 batches will lead to sizes [3,3,2,2]."""
     base_numbers_of_files = [nb_files // nb_batches] * nb_batches
     remainder_files = nb_files % nb_batches
     return [nb_files+1 if index < remainder_files else nb_files for index,nb_files in enumerate(base_numbers_of_files)]
@@ -75,7 +137,8 @@ if __name__ == "__main__":
     datetime_begin = pd.Timestamp(args.datetime_begin)
     datetime_end = pd.Timestamp(args.datetime_end)
 
-    files = _get_batch_files(datetime_begin=datetime_begin, datetime_end=datetime_end, batch_index = args.batch_index, total_number_of_batches = args.nb_batches, audio_folder = dataset.audio_path)
+    all_processed_files = _get_all_processed_files(datetime_begin=datetime_begin, datetime_end=datetime_end, audio_folder = dataset.audio_path)
+    files = _get_files_processed_by_current_batch(all_processed_files, batch_index = args.batch_index, total_number_of_batches = args.nb_batches)
 
     if missing_files := [file for file in files if not file.exists()]:
         missing_file_list = "\n".join(str(file) for file in missing_files)

--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -11,7 +11,7 @@ from OSmOSE.config import OSMOSE_PATH
 from OSmOSE.cluster import reshape
 from OSmOSE.utils.audio_utils import get_all_audio_files
 from OSmOSE.utils.core_utils import add_entry_for_APLOSE
-
+from OSmOSE.utils.timestamp_utils import strftime_osmose_format
 
 def adjust_spectro(
     dataset: Spectrogram, number_adjustment_spectrogram: int = 1, file_list: [str] = []
@@ -35,10 +35,9 @@ def adjust_spectro(
     if number_adjustment_spectrogram == 0:
         return
 
-    dataset.audio_path = dataset.original_folder
 
     temp_adjustment_output_dir = (
-        dataset.audio_path.parent
+        dataset.original_folder.parent
         / f"temp_{dataset.spectro_duration}_{dataset.dataset_sr}"
     )
 
@@ -51,7 +50,7 @@ def adjust_spectro(
             "WARNING: the spectrogram normalization has been changed to spectrum because the data will be normalized using zscore."
         )
 
-    file_metadata = pd.read_csv(dataset.audio_path / "file_metadata.csv")
+    file_metadata = pd.read_csv(dataset.original_folder / "file_metadata.csv")
 
     if len(file_list) > 0:
         if all([f in file_metadata["filename"].values for f in file_list]):
@@ -149,7 +148,7 @@ def generate_spectro(
     ), f"'path_osmose_dataset' must be a path, {path_osmose_dataset} not a valid value"
 
     file_metadata = pd.read_csv(
-        dataset.path_input_audio_file / "file_metadata.csv", parse_dates=["timestamp"]
+        dataset.original_folder / "file_metadata.csv", parse_dates=["timestamp"]
     )
 
     if not datetime_begin:
@@ -169,6 +168,8 @@ def generate_spectro(
             datetime_end = pd.Timestamp(datetime_end)
         except Exception as e:
             raise ValueError(f"'datetime_end' not a valid datetime: {e}")
+    datetime_begin = strftime_osmose_format(datetime_begin)
+    datetime_end = strftime_osmose_format(datetime_end)
 
     if write_datasets_csv_for_aplose is True:
 
@@ -200,16 +201,10 @@ def generate_spectro(
     job_files = []
 
     dataset.prepare_paths()
-
-    files = _files_in_analysis(datetime_begin=datetime_begin, datetime_end=datetime_end, audio_folder=dataset.audio_path)
-    batch_sizes = _compute_batch_sizes(nb_files = len(files), nb_batches = dataset.batch_number)
-    batch_indexes = [sum(batch_sizes[:i]) for i in range(len(batch_sizes))]
     
     spectrogram_metadata_path = dataset.save_spectro_metadata(False)
 
-    for batch in range(len(batch_indexes)):
-        first_file_index = batch_indexes[batch]
-        last_file_index = first_file_index + batch_sizes[batch]
+    for batch in range(dataset.batch_number):
 
         job_file = dataset.jb.build_job_file(
             script_path=Path(os.path.abspath("../src")).joinpath(
@@ -217,9 +212,11 @@ def generate_spectro(
             ),
             script_args=f"--dataset-path {dataset.path} "
             f"--dataset-sr {dataset.dataset_sr} "
-            f"--spectrogram-metadata-path {spectrogram_metadata_path} "                        
-            f"--files {' '.join(files[first_file_index:last_file_index])} "
-            f"--first-file-index {first_file_index} "
+            f"--spectrogram-metadata-path {spectrogram_metadata_path} "
+            f"--datetime-begin {datetime_begin} "
+            f"--datetime-end {datetime_end} "
+            f"--batch-index {batch} "
+            f"--nb-batches {dataset.batch_number} "
             f"{'--overwrite ' if overwrite else ''}"
             f"{'--save-for-LTAS ' if save_welch else ''}"
             f"{'--save-matrix ' if save_matrix else ''}",
@@ -377,18 +374,6 @@ def display_progress(
         str(number_spectro_to_process),
         ")",
     )
-
-def _files_in_analysis(datetime_begin: pd.Timestamp, datetime_end: pd.Timestamp, audio_folder: Path) -> list[str]:
-    timestamps = pd.read_csv(audio_folder / "timestamp.csv")
-    file_duration = float(pd.read_csv(audio_folder / "metadata.csv")["audio_file_dataset_duration"][0])
-    timestamps["begin"] = timestamps["timestamp"].apply(lambda t: pd.Timestamp(t))
-    timestamps["end"] = timestamps["begin"] + pd.Timedelta(seconds=file_duration)
-    return [str(audio_folder/filename) for filename in timestamps.loc[(datetime_begin < timestamps["end"]) & (datetime_end > timestamps["begin"]), "filename"]]
-
-def _compute_batch_sizes(nb_files: int, nb_batches: int):
-    base_numbers_of_files = [nb_files // nb_batches] * nb_batches
-    remainder_files = nb_files % nb_batches
-    return [nb_files+1 if index < remainder_files else nb_files for index,nb_files in enumerate(base_numbers_of_files)]
 
 def monitor_job(dataset: Spectrogram):
     """


### PR DESCRIPTION
I broke the enqueuing of the `generate_spectro()` jobs in a situation where the audio file reshaping (`Dataset.initialize()`) was not finished in #64 .

This PR goes back to the logic where **each batch** computes the whole list of processed files and finds out which wones it has to process. It's a bit weird, but it is the simplest way atm (in the future, I guess we could start by computing the future `timestamp.csv` before actually reshaping the audio or something like that?)

I tests it on a continuous dataset and it seems to work. I still have to perform some tests before merging this.