### PR TITLE
fix broken creation of a prepared job on generate_spectro

### DIFF
--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -231,8 +231,6 @@ def generate_spectro(
             logdir=log_dir,
         )
 
-        job_files.append(job_file)
-
     if hasattr(dataset, "pending_jobs"):
         pending_jobs = [
             jobid
@@ -243,16 +241,12 @@ def generate_spectro(
     else:
         pending_jobs = []
 
-    job_id_list = [
-        dataset.jb.submit_job(jobfile=job_file, dependency=pending_jobs)
-        for job_file in job_files
-    ]  # submit all built job files
+    job_id_list = dataset.jb.submit_job(dependency=pending_jobs) # submit all built job files
     nb_jobs = len(dataset.jb.finished_jobs) + len(job_id_list)
 
     if pending_jobs:
         print(f"pending job ids: {pending_jobs}")
     print(f"The job ids are {job_id_list}")
-
 
 def display_progress(
     dataset: Spectrogram,


### PR DESCRIPTION
I introduced a bug in #57 without noticing it, by misinterprenting the way the job buider works.

This led to creating incomplete jobs in the outgoing list, and broke the code if other jobs were created later on.

I reversed the changes that led to the bug, which does seem to work as intended.