### PR TITLE
Hotfix/display progress

### DIFF
--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -149,23 +149,8 @@ def generate_spectro(
         dataset.original_folder / "file_metadata.csv", parse_dates=["timestamp"]
     )
 
-    if not datetime_begin:
-        datetime_begin = file_metadata["timestamp"].iloc[0]
-    else:
-        try:
-            datetime_begin = pd.Timestamp(datetime_begin)
-        except Exception as e:
-            raise ValueError(f"'datetime_begin' not a valid datetime: {e}")
+    datetime_begin, datetime_end = _clip_timestamps(begin=datetime_begin, end=datetime_end, file_metadata=file_metadata)
 
-    if not datetime_end:
-        datetime_end = file_metadata["timestamp"].iloc[-1] + pd.Timedelta(
-            file_metadata["duration"].iloc[-1], unit="s"
-        )
-    else:
-        try:
-            datetime_end = pd.Timestamp(datetime_end)
-        except Exception as e:
-            raise ValueError(f"'datetime_end' not a valid datetime: {e}")
     datetime_begin = strftime_osmose_format(datetime_begin)
     datetime_end = strftime_osmose_format(datetime_end)
 
@@ -438,3 +423,23 @@ def read_job(job_id: str, dataset: Spectrogram):
             raise FileNotFoundError
     else:
         glc.logger.info(f"{job_id} not in finished jobs")
+
+def _clip_timestamps(begin: os.PathLike or str or None, end: os.PathLike or str or None, file_metadata: pd.DataFrame):
+    if not begin:
+        begin = file_metadata["timestamp"].iloc[0]
+    else:
+        try:
+            begin = pd.Timestamp(begin)
+        except Exception as e:
+            raise ValueError(f"'datetime_begin' not a valid datetime: {e}")
+
+    if not end:
+        end = file_metadata["timestamp"].iloc[-1] + pd.Timedelta(
+            file_metadata["duration"].iloc[-1], unit="s"
+        )
+    else:
+        try:
+            end = pd.Timestamp(end)
+        except Exception as e:
+            raise ValueError(f"'datetime_end' not a valid datetime: {e}")
+    return begin, end

--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -266,20 +266,6 @@ def display_progress(
         2**i for i in range(dataset.zoom_level + 1)
     )
 
-    # counting the skipped files
-    out_file = [
-        str(job["outfile"])
-        for job in dataset.jb.finished_jobs
-        if "reshape" in str(job["outfile"])
-    ]
-
-    skipped = 0
-    if out_file:
-        for file in out_file:
-            with open(file, "r") as f:
-                skipped += sum(line.count("Skipping...") for line in f)
-        number_audio_file += skipped
-
     if number_audio_file == target_nb_files:
         status = "DONE"
         dataset.jb.update_job_status()
@@ -290,7 +276,6 @@ def display_progress(
     glc.logger.info(f"o Audio file preparation : {status} ({number_audio_file}/{target_nb_files})")
 
     glc.logger.info(f"\t- Generated audio: {len(get_all_audio_files(dataset.audio_path))}")
-    glc.logger.info(f"\t- Discarded audio: {skipped}")
 
     if number_spectro == number_spectro_to_process:
         status = "DONE"

--- a/src/utils_datarmor.py
+++ b/src/utils_datarmor.py
@@ -12,6 +12,8 @@ from OSmOSE.cluster import reshape
 from OSmOSE.utils.audio_utils import get_all_audio_files
 from OSmOSE.utils.core_utils import add_entry_for_APLOSE
 from OSmOSE.utils.timestamp_utils import strftime_osmose_format
+
+
 def adjust_spectro(
     dataset: Spectrogram, number_adjustment_spectrogram: int = 1, file_list: [str] = []
 ):
@@ -145,11 +147,7 @@ def generate_spectro(
         path_osmose_dataset, str | Path
     ), f"'path_osmose_dataset' must be a path, {path_osmose_dataset} not a valid value"
 
-    file_metadata = pd.read_csv(
-        dataset.original_folder / "file_metadata.csv", parse_dates=["timestamp"]
-    )
-
-    datetime_begin, datetime_end = _clip_timestamps(begin=datetime_begin, end=datetime_end, file_metadata=file_metadata)
+    datetime_begin, datetime_end = _clip_timestamps(begin=datetime_begin, end=datetime_end, dataset=dataset)
 
     datetime_begin = strftime_osmose_format(datetime_begin)
     datetime_end = strftime_osmose_format(datetime_end)
@@ -249,6 +247,9 @@ def display_progress(
     assert isinstance(
         dataset, Spectrogram
     ), "Not a Spectrogram object passed, display aborted"
+
+    datetime_begin, datetime_end = _clip_timestamps(begin=datetime_begin, end=datetime_end, dataset=dataset)
+
     assert isinstance(
         datetime_begin, pd.Timestamp
     ), f"'{datetime_begin}' not a valid timestamp"
@@ -424,7 +425,12 @@ def read_job(job_id: str, dataset: Spectrogram):
     else:
         glc.logger.info(f"{job_id} not in finished jobs")
 
-def _clip_timestamps(begin: os.PathLike or str or None, end: os.PathLike or str or None, file_metadata: pd.DataFrame):
+def _clip_timestamps(begin: pd.Timestamp or str or None, end: pd.Timestamp or str or None, dataset: Spectrogram):
+
+    file_metadata = pd.read_csv(
+        dataset.original_folder / "file_metadata.csv", parse_dates=["timestamp"]
+    )
+
     if not begin:
         begin = file_metadata["timestamp"].iloc[0]
     else:


### PR DESCRIPTION
I resolved the bug where the fonction raised an error if no begin/end timestamps were given with the `_clip_timestamps` function.

Yet, the whole function was still quite buggy: it grabbed abritrary files for computing the progress, didn't properly take into account the provided timestamps, lots of stuff like that.

I already spent too much time on this since it will most likely get simplified **a lot** in the future, but the best I found to do was to approximate the number of processed files based on the timestamps and time coverage of the original audio files.

There still seems to be a bug when files are skipped (it looks for a job file that doesn't exist anymore), but re-running the function works (I think @mathieudpnt  already encountered that in the past?)

It's far from perfect, but it can hint to check the job status if the number of output files approaches the approximated target number of files.